### PR TITLE
build: add static lib build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,15 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wunused -Werror")
 
 file(GLOB SOURCES src/*.c)
 
-# Shared library
-add_library(hashmap SHARED ${SOURCES})
-target_include_directories(hashmap PUBLIC src)
+# Static library build option
+option(HASHMAP_STATIC_LIB "Build static libhashmap" OFF)
+
+if(HASHMAP_STATIC_LIB)
+    # Static library
+    add_library(${PROJECT_NAME} STATIC ${SOURCES})
+else()
+    # Shared library
+    add_library(${PROJECT_NAME} SHARED ${SOURCES})
+endif()
+
+target_include_directories(${PROJECT_NAME} PUBLIC src)


### PR DESCRIPTION
# Add static lib build option
This change adds an option (HASHMAP_STATIC_LIB) that let us build a static library instead of a shared one.
This will allow the library to be easily integrated into other CMake-based projects.
It doesn't change the default behavior (Builds by default a shared library).

**Use case: Integrate into an other project**
set(HASHMAP_STATIC_LIB ON)
add_subdirectory(libs/hashmap)
 
