### PR TITLE
Include standard headers to use `bool` and `size_t`

### DIFF
--- a/include/hashmap_base.h
+++ b/include/hashmap_base.h
@@ -6,6 +6,8 @@
  */
 
 #pragma once
+#include <stdbool.h>
+#include <stddef.h>
 
 struct hashmap_entry;
 


### PR DESCRIPTION
Hi, I'd like to propose a small fix that fixing the compilation error about unknown type `bool` and removes linting warnings about `size_t` when `hashmap_base.h` is opened.

The first is an actual error, at least with Clang 14 on macOS. The warning about `size_t` does not lead to errors, as `stddefs.h` in `hashmap.h` is included, however, inside Neovim, linting with `clang++` (and C++14 standard) leads to these warnings.