### PR TITLE
build: update CMake versions and language standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required(VERSION 3.5)
-project(hashmap VERSION 2.0.0 LANGUAGES C)
+cmake_minimum_required(VERSION 3.16)
+project(hashmap VERSION 2.1.0 LANGUAGES C)
 
-set(CMAKE_C_STANDARD 11)
+if(NOT DEFINED CMAKE_C_STANDARD)
+    set(CMAKE_C_STANDARD 23)
+    set(CMAKE_C_EXTENSIONS OFF)
+endif()
 
 ##############################################
 # Build options
@@ -36,7 +39,7 @@ target_include_directories(hashmap
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 target_compile_options(hashmap
-    PRIVATE $<$<C_COMPILER_ID:GNU>:-Wall -Werror>
+    PRIVATE -Wall -Werror
 )
 
 ##############################################

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
 # Hashmap example
 add_executable(hashmap_example hashmap_example.c)
 target_compile_options(hashmap_example PRIVATE -Wall -Werror)

--- a/examples/hashmap_example.c
+++ b/examples/hashmap_example.c
@@ -38,9 +38,9 @@ struct blob *blob_load(void)
     if ((b = malloc(sizeof(*b))) == NULL) {
         return NULL;
     }
-    snprintf(b->key, sizeof(b->key), "%02lx", random() % 100);
-    b->data_len = random() % 10;
-    memset(b->data, random(), b->data_len);
+    snprintf(b->key, sizeof(b->key), "%02x", rand() % 100);
+    b->data_len = rand() % 10;
+    memset(b->data, rand(), b->data_len);
 
     return b;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.19)
 project(hashmap_test)
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 20)
+if(NOT DEFINED CMAKE_C_STANDARD)
+    set(CMAKE_C_STANDARD 23)
+    set(CMAKE_C_EXTENSIONS OFF)
+endif()
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+endif()
 
 include(FetchContent)
 


### PR DESCRIPTION
The `typeof` keyword used by this library only became available in the C23 standard. Previously, it was available as a gnu and clang extension. Also, updated the example to use rand() instead of random(). This is an older function, but is more portable.